### PR TITLE
CIDR Notated Rules

### DIFF
--- a/pkg/rules/cidr.go
+++ b/pkg/rules/cidr.go
@@ -1,0 +1,56 @@
+package rules
+
+import (
+	"encoding/binary"
+	"net"
+	"strings"
+)
+
+type IPAddr []uint32
+
+func NewIPAddr(ip net.IP) IPAddr {
+	if ip == nil {
+		return nil
+	}
+	tmpIp := ip.To4()
+	length := 1
+	if tmpIp == nil {
+		tmpIp = ip.To16()
+		length = 4
+	}
+	if tmpIp == nil {
+		return nil
+	}
+	addr := make(IPAddr, length)
+	for i := 0; i < length; i++ {
+		idx := i * net.IPv4len
+		addr[i] = binary.BigEndian.Uint32(tmpIp[idx : idx+net.IPv4len])
+	}
+	return addr
+}
+
+func NetworkContains(network net.IPNet, ip net.IP) bool {
+	addr := NewIPAddr(ip)
+	number := NewIPAddr(network.IP)
+	mask := NewIPAddr(net.IP(network.Mask))
+	if len(mask) != len(addr) {
+		return false
+	}
+	if addr[0]&mask[0] != number[0] {
+		return false
+	}
+	if len(addr) == 4 {
+		return addr[1]&mask[1] == number[1] &&
+			addr[2]&mask[2] == number[2] &&
+			addr[3]&mask[3] == number[3]
+	}
+	return true
+}
+
+func IsCIDR(s string) bool {
+	if !strings.Contains(s, "/") {
+		return false
+	}
+	_, _, err := net.ParseCIDR(s)
+	return err == nil
+}

--- a/pkg/rules/cidr.go
+++ b/pkg/rules/cidr.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 )
 
+// IPAddr represents an IP address as an array of 4-byte chunks.
 type IPAddr []uint32
 
+// NewIPAddr converts a network IP to an IPAddr and returns it.
 func NewIPAddr(ip net.IP) IPAddr {
 	if ip == nil {
 		return nil
@@ -29,6 +31,8 @@ func NewIPAddr(ip net.IP) IPAddr {
 	return addr
 }
 
+// NetworkContains returns true if the given network IP is contained in the
+// given network range.
 func NetworkContains(network net.IPNet, ip net.IP) bool {
 	addr := NewIPAddr(ip)
 	number := NewIPAddr(network.IP)
@@ -47,6 +51,7 @@ func NetworkContains(network net.IPNet, ip net.IP) bool {
 	return true
 }
 
+// IsCIDR returns true if the given string is formatted in CIDR notation.
 func IsCIDR(s string) bool {
 	if !strings.Contains(s, "/") {
 		return false

--- a/pkg/rules/cidr_test.go
+++ b/pkg/rules/cidr_test.go
@@ -1,0 +1,58 @@
+package rules
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIPAddr(t *testing.T) {
+	tests := []struct {
+		IP       string
+		Expected []uint32
+	}{
+		{"127.126.125.124", []uint32{2138996092}},
+		{"2a02:ff0:2f9:b707::1", []uint32{704778224, 49919751, 0, 1}},
+	}
+	for _, test := range tests {
+		actual := NewIPAddr(net.ParseIP(test.IP))
+		require.Equal(t, test.Expected, []uint32(actual))
+	}
+}
+
+func TestNetworkContains(t *testing.T) {
+	tests := []struct {
+		Network  string
+		IP       string
+		Expected bool
+	}{
+		{"192.128.0.0/24", "192.128.2.10", false},
+		{"192.128.0.0/24", "192.128.0.0", true},
+		{"192.128.0.0/24", "192.128.0.255", true},
+		{"2a02::0/120", "2a02:ff0:2f9:b707::1", false},
+		{"2a02::0/120", "2a02::0", true},
+		{"2a02::0/120", "2a02::ff", true},
+	}
+	for _, test := range tests {
+		_, n, err := net.ParseCIDR(test.Network)
+		require.Nil(t, err)
+		ip := net.ParseIP(test.IP)
+		require.Equal(t, test.Expected, NetworkContains(*n, ip))
+	}
+}
+
+func TestIsCIDR(t *testing.T) {
+	tests := []struct {
+		Network  string
+		Expected bool
+	}{
+		{"192.128.0.0", false},
+		{"192.128.0.0/24", true},
+		{"2a02::0", false},
+		{"2a02::0/120", true},
+	}
+	for _, test := range tests {
+		require.Equal(t, test.Expected, IsCIDR(test.Network))
+	}
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -44,6 +44,8 @@ func (r Rule) Matches(req *http.Request) bool {
 	for _, cond := range r.Conditions {
 		// Match the condition's key
 		actual := ""
+		expected := cond.Value()
+		op := cond.Operator()
 		switch NewConditionKey(cond.Key()) {
 		case ConditionKeyHost:
 			actual = req.Host
@@ -53,15 +55,17 @@ func (r Rule) Matches(req *http.Request) bool {
 			actual = req.URL.Path
 		case ConditionKeySourceIp:
 			actual = getIpFromRequest(req).String()
+			if IsCIDR(expected) {
+				return matchCIDR(expected, actual, op)
+			}
 		case ConditionKeyAlways:
 			return true
 		default:
 			return false
 		}
 		// Retrieve the conditions operation and perform it.
-		expected := cond.Value()
 		good := false
-		switch cond.Operator() {
+		switch op {
 		case ConditionOpEqualInsensitive:
 			fallthrough
 		case ConditionOpEqual:
@@ -103,4 +107,25 @@ func getIpFromRequest(r *http.Request) net.IP {
 		}
 	}
 	return nil
+}
+
+func matchCIDR(netStr, ipStr string, op ConditionOp) bool {
+	fmt.Println(netStr, ipStr)
+	_, n, err := net.ParseCIDR(netStr)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(ipStr)
+	contains := NetworkContains(*n, ip)
+	switch op {
+	case ConditionOpEqualInsensitive:
+		fallthrough
+	case ConditionOpEqual:
+		return contains
+	case ConditionOpNotEqualInsensitive:
+		fallthrough
+	case ConditionOpNotEqual:
+		return !contains
+	}
+	return false
 }

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -109,6 +109,8 @@ func getIpFromRequest(r *http.Request) net.IP {
 	return nil
 }
 
+// matchCIDR returns true if the IP address string is contained or not contained
+// in the given network range string depending on the operation.
 func matchCIDR(netStr, ipStr string, op ConditionOp) bool {
 	_, n, err := net.ParseCIDR(netStr)
 	if err != nil {

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -110,7 +110,6 @@ func getIpFromRequest(r *http.Request) net.IP {
 }
 
 func matchCIDR(netStr, ipStr string, op ConditionOp) bool {
-	fmt.Println(netStr, ipStr)
 	_, n, err := net.ParseCIDR(netStr)
 	if err != nil {
 		return false


### PR DESCRIPTION
### Description
Ticket: OxFIY-2022821
- Adds CIDR ranges to `source-ip` conditions
- CIDR ranges only work for equality statements (E.g. "=", "!=")
- IPv4 and IPv6 CIDR support